### PR TITLE
Fix tile collision on downward and rightward movement

### DIFF
--- a/src/main/CollisionChecker.java
+++ b/src/main/CollisionChecker.java
@@ -35,7 +35,7 @@ public class CollisionChecker {
         }
         break;
       case DOWN:
-        entityBottomRow = (entityBottomWorldY - entity.speed) / gp.TILE_SIZE;
+        entityBottomRow = (entityBottomWorldY + entity.speed) / gp.TILE_SIZE;
         tileNum1 = gp.tileManager.mapTileNum[entityLeftCol][entityBottomRow];
         tileNum2 = gp.tileManager.mapTileNum[entityRightCol][entityBottomRow];
         if (gp.tileManager.tiles[tileNum1].collision || gp.tileManager.tiles[tileNum2].collision) {
@@ -55,7 +55,7 @@ public class CollisionChecker {
         }
         break;
       case RIGHT:
-        entityRightCol = (entityRightWorldX - entity.speed) / gp.TILE_SIZE;
+        entityRightCol = (entityRightWorldX + entity.speed) / gp.TILE_SIZE;
         tileNum1 = gp.tileManager.mapTileNum[entityRightCol][entityTopRow];
         tileNum2 = gp.tileManager.mapTileNum[entityRightCol][entityBottomRow];
         if (gp.tileManager.tiles[tileNum1].collision || gp.tileManager.tiles[tileNum2].collision) {


### PR DESCRIPTION
## Summary
- fix incorrect tile index calculations for DOWN and RIGHT directions

## Testing
- `javac $(find src -name '*.java')`
- `java src.main.Main` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_683f5938d1048326a7cfbd0e04d11ce5